### PR TITLE
Fixed ImportError: cannot import name 'BinarySpaceToDiscreteSpaceEnv'…

### DIFF
--- a/Chapter 8/Ch8_book.ipynb
+++ b/Chapter 8/Ch8_book.ipynb
@@ -22,11 +22,11 @@
    "outputs": [],
    "source": [
     "import gym\n",
-    "from nes_py.wrappers import BinarySpaceToDiscreteSpaceEnv #A\n",
+    "from nes_py.wrappers import JoypadSpace #A\n",
     "import gym_super_mario_bros\n",
     "from gym_super_mario_bros.actions import SIMPLE_MOVEMENT, COMPLEX_MOVEMENT #B\n",
     "env = gym_super_mario_bros.make('SuperMarioBros-v0')\n",
-    "env = BinarySpaceToDiscreteSpaceEnv(env, COMPLEX_MOVEMENT) #C"
+    "env = JoypadSpace(env, COMPLEX_MOVEMENT) #C"
    ]
   },
   {

--- a/Chapter 8/Curiosity-Driven Exploration Super Mario.ipynb
+++ b/Chapter 8/Curiosity-Driven Exploration Super Mario.ipynb
@@ -34,11 +34,11 @@
     "from IPython import display\n",
     "\n",
     "import gym\n",
-    "from nes_py.wrappers import BinarySpaceToDiscreteSpaceEnv\n",
+    "from nes_py.wrappers import JoypadSpace\n",
     "import gym_super_mario_bros\n",
     "from gym_super_mario_bros.actions import SIMPLE_MOVEMENT, COMPLEX_MOVEMENT\n",
     "env = gym_super_mario_bros.make('SuperMarioBros-v0')\n",
-    "env = BinarySpaceToDiscreteSpaceEnv(env, COMPLEX_MOVEMENT)\n",
+    "env = JoypadSpace(env, COMPLEX_MOVEMENT)\n",
     "%matplotlib inline"
    ]
   },


### PR DESCRIPTION
… from 'nes_py.wrappers'

Issue: `ImportError: cannot import name 'BinarySpaceToDiscreteSpaceEnv' from 'nes_py.wrappers'` in Chapter 8 code
Root cause: `nes-py` library changes `BinarySpaceToDiscreteSpaceEnv` to `JoypadSpace` function since Jun 3, 2019
Reference:
https://github.com/Kautenja/nes-py/commit/6f47b75
https://github.com/Kautenja/nes-py/wiki/Wrappers