### PR TITLE
Fix wrong indentation in the MNIST example training loop

### DIFF
--- a/Chapter 10/Ch10_book.ipynb
+++ b/Chapter 10/Ch10_book.ipynb
@@ -186,7 +186,7 @@
     "    correct[[rows,yt.detach().long()]] = 1.\n",
     "    loss = lossfn(pred,yt)\n",
     "    loss.backward()\n",
-    "opt.step()"
+    "    opt.step()"
    ]
   },
   {


### PR DESCRIPTION
opt.step() should be in the `for` loop.