### PR TITLE
Fix: state => state1

### DIFF
--- a/Chapter 3/Ch3_book.ipynb
+++ b/Chapter 3/Ch3_book.ipynb
@@ -141,7 +141,7 @@
     "for i in range(epochs): #B\n",
     "    game = Gridworld(size=4, mode='static') #C\n",
     "    state_ = game.board.render_np().reshape(1,64) + np.random.rand(1,64)/10.0 #D\n",
-    "    state = torch.from_numpy(state_).float() #E\n",
+    "    state1 = torch.from_numpy(state_).float() #E\n",
     "    status = 1 #F\n",
     "    while(status == 1): #G\n",
     "        qval = model(state1) #H\n",


### PR DESCRIPTION
The book correctly refers to this as `state1`, whereas here it just overrides `state`. With no `state1` declared, this will just error out.