### PR TITLE
Ch7 listing 7.2 `update_dist` the support parameter is unused

### DIFF
--- a/Chapter 7/Ch7_book.ipynb
+++ b/Chapter 7/Ch7_book.ipynb
@@ -83,7 +83,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def update_dist(r,support,probs,lim=(-10.,10.),gamma=0.8):\n",
+    "def update_dist(r,probs,lim=(-10.,10.),gamma=0.8):\n",
     "    nsup = probs.shape[0]\n",
     "    vmin,vmax = lim[0],lim[1]\n",
     "    dz = (vmax-vmin)/(nsup-1.) #A\n",


### PR DESCRIPTION
It seems the `support` parameter to `update_dist` is unused?

Page 187 in the paper version.